### PR TITLE
Use AWSCredentialsProvider instead of passing around AWSCredentials

### DIFF
--- a/app/actors/workflow/AmazonCredentials.scala
+++ b/app/actors/workflow/AmazonCredentials.scala
@@ -23,7 +23,7 @@ class AmazonCredentials extends Actor with ActorLogging {
 
   override def postStop() = tick.cancel()
 
-  var credentials: Option[AWSCredentials] = None
+  var credentialProvider: Option[AWSCredentialsProvider] = None
 
   override def receive: Receive = {
     case Tick =>
@@ -36,7 +36,7 @@ class AmazonCredentials extends Actor with ActorLogging {
       loadCreds()
 
     case RequestCredentials =>
-      sender() ! (credentials match {
+      sender() ! (credentialProvider match {
         case Some(x) => CurrentCredentials(x)
         case None => NoCredentials
       })
@@ -58,7 +58,7 @@ class AmazonCredentials extends Actor with ActorLogging {
         case "SystemPropertiesCredentialsProvider" => new SystemPropertiesCredentialsProvider()
       }
 
-      credentials = Some(provider.getCredentials)
+      credentialProvider = Some(provider)
     } catch {
       case ex: Exception => {
         log.debug("Error loading credentials...leaving them as-is. ", ex)
@@ -73,5 +73,5 @@ object AmazonCredentials {
   case object RequestCredentials
   case object ForceReload
   case object NoCredentials
-  case class CurrentCredentials(credentials: AWSCredentials)
+  case class CurrentCredentials(credentials: AWSCredentialsProvider)
 }

--- a/app/actors/workflow/WorkflowManager.scala
+++ b/app/actors/workflow/WorkflowManager.scala
@@ -13,7 +13,7 @@ import actors.workflow.steps.TearDownSupervisor.{TearDownCommand, TearDownFinish
 import actors.workflow.steps.ValidateAndFreezeSupervisor._
 import actors.workflow.steps._
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json.Json
 import utils.{ActorFactory, PropFactory}
@@ -265,8 +265,8 @@ object WorkflowManager extends PropFactory {
   sealed trait WorkflowData
   case object Uninitialized extends WorkflowData
   case class DeployData(deploy: Deploy) extends WorkflowData
-  case class DeployDataWithCreds(deploy: Deploy, creds: AWSCredentials) extends WorkflowData
-  case class DeployDataWithCredsWithSteps(deploy: Deploy, creds: AWSCredentials,
+  case class DeployDataWithCreds(deploy: Deploy, creds: AWSCredentialsProvider) extends WorkflowData
+  case class DeployDataWithCredsWithSteps(deploy: Deploy, creds: AWSCredentialsProvider,
                                           stepData: Map[String, String] = Map.empty[String, String]) extends WorkflowData
   case class DeleteData(stackName: String) extends WorkflowData
 

--- a/app/actors/workflow/steps/DeleteStackSupervisor.scala
+++ b/app/actors/workflow/steps/DeleteStackSupervisor.scala
@@ -5,13 +5,13 @@ import actors.workflow.steps.DeleteStackSupervisor.{DeleteStackData, DeleteStack
 import actors.workflow.tasks.DeleteStack.{DeleteStackCommand, StackDeleteRequested}
 import actors.workflow.tasks.StackDeleteCompleteMonitor.StackDeleteCompleted
 import actors.workflow.tasks.StackInfo.StackIdQuery
-import actors.workflow.tasks.{StackDeleteCompleteMonitor, DeleteStack, StackInfo}
+import actors.workflow.tasks.{DeleteStack, StackDeleteCompleteMonitor, StackInfo}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
-import utils.{PropFactory, ActorFactory}
+import com.amazonaws.auth.AWSCredentialsProvider
+import utils.{ActorFactory, PropFactory}
 
-class DeleteStackSupervisor(credentials: AWSCredentials,
+class DeleteStackSupervisor(credentials: AWSCredentialsProvider,
                             actorFactory: ActorFactory) extends FSM[DeleteStackStates, DeleteStackData]
                                                                 with ActorLogging with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/HealthyInstanceSupervisor.scala
+++ b/app/actors/workflow/steps/HealthyInstanceSupervisor.scala
@@ -10,7 +10,7 @@ import actors.workflow.tasks.{ASGInfo, ELBHealthyInstanceChecker}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor.FSM.Failure
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.typesafe.config.ConfigFactory
 import utils.ConfigHelpers._
 import utils.{ActorFactory, PropFactory}
@@ -18,7 +18,7 @@ import utils.{ActorFactory, PropFactory}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class HealthyInstanceSupervisor(credentials: AWSCredentials, expectedInstances: Int, asgName: String,
+class HealthyInstanceSupervisor(credentials: AWSCredentialsProvider, expectedInstances: Int, asgName: String,
                                 actorFactory: ActorFactory) extends FSM[HealthyInstanceMonitorStates, HealthyInstanceData]
                                                                     with ActorLogging with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/LoadStackSupervisor.scala
+++ b/app/actors/workflow/steps/LoadStackSupervisor.scala
@@ -6,11 +6,11 @@ import actors.workflow.tasks.StackLoader
 import actors.workflow.tasks.StackLoader.{LoadStack, StackLoaded}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import play.api.libs.json.JsValue
 import utils.{PropFactory, ActorFactory}
 
-class LoadStackSupervisor(credentials: AWSCredentials,
+class LoadStackSupervisor(credentials: AWSCredentialsProvider,
                           actorFactory: ActorFactory) extends FSM[LoadStackStates, LoadStackData] with ActorLogging
                                                               with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/NewStackSupervisor.scala
+++ b/app/actors/workflow/steps/NewStackSupervisor.scala
@@ -12,11 +12,11 @@ import actors.workflow.tasks.StackInfo.{StackASGNameQuery, StackASGNameResponse}
 import actors.workflow.tasks._
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import play.api.libs.json.JsValue
 import utils.{ActorFactory, PropFactory}
 
-class NewStackSupervisor(credentials: AWSCredentials,
+class NewStackSupervisor(credentials: AWSCredentialsProvider,
                          actorFactory: ActorFactory) extends FSM[NewStackState, NewStackData] with ActorLogging
                                                              with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/RollBackStackSupervisor.scala
+++ b/app/actors/workflow/steps/RollBackStackSupervisor.scala
@@ -9,10 +9,10 @@ import actors.workflow.tasks.UnfreezeASG.{UnfreezeASGCommand, UnfreezeASGComplet
 import actors.workflow.tasks.{DeleteStack, StackDeleteCompleteMonitor, StackInfo, UnfreezeASG}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor.{ActorLogging, FSM, Props, Terminated}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import utils.{ActorFactory, PropFactory}
 
-class RollBackStackSupervisor(credentials: AWSCredentials,
+class RollBackStackSupervisor(credentials: AWSCredentialsProvider,
                               actorFactory: ActorFactory) extends FSM[RollBackState, RollBackData] with ActorLogging
                                                                   with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/TearDownSupervisor.scala
+++ b/app/actors/workflow/steps/TearDownSupervisor.scala
@@ -9,10 +9,10 @@ import actors.workflow.tasks.UnfreezeASG.{UnfreezeASGCommand, UnfreezeASGComplet
 import actors.workflow.tasks.{DeleteStack, StackDeleteCompleteMonitor, StackInfo, UnfreezeASG}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import utils.{ActorFactory, PropFactory}
 
-class TearDownSupervisor(credentials: AWSCredentials,
+class TearDownSupervisor(credentials: AWSCredentialsProvider,
                          actorFactory: ActorFactory) extends FSM[TearDownState, TearDownData] with ActorLogging
                                                              with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/steps/ValidateAndFreezeSupervisor.scala
+++ b/app/actors/workflow/steps/ValidateAndFreezeSupervisor.scala
@@ -11,10 +11,10 @@ import actors.workflow.tasks.StackList.{FilteredStacks, ListNonDeletedStacksStar
 import actors.workflow.tasks.{FreezeASG, StackInfo, StackList}
 import actors.workflow.{AWSSupervisorStrategy, WorkflowManager}
 import akka.actor._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import utils.{ActorFactory, PropFactory}
 
-class ValidateAndFreezeSupervisor(credentials: AWSCredentials,
+class ValidateAndFreezeSupervisor(credentials: AWSCredentialsProvider,
                                   actorFactory: ActorFactory) extends FSM[ValidateAndFreezeStates, ValidateAndFreezeData]
                                                                       with ActorLogging with AWSSupervisorStrategy {
 

--- a/app/actors/workflow/tasks/ASGInfo.scala
+++ b/app/actors/workflow/tasks/ASGInfo.scala
@@ -2,13 +2,13 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import utils.{AmazonAutoScalingService, PropFactory}
 
 import scala.collection.JavaConverters._
 
-class ASGInfo(credentials: AWSCredentials) extends AWSRestartableActor with AmazonAutoScalingService {
+class ASGInfo(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonAutoScalingService {
 
   import actors.workflow.tasks.ASGInfo._
 

--- a/app/actors/workflow/tasks/ASGSize.scala
+++ b/app/actors/workflow/tasks/ASGSize.scala
@@ -2,13 +2,13 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, SetDesiredCapacityRequest}
 import utils.{AmazonAutoScalingService, PropFactory}
 
 import scala.collection.JavaConverters._
 
-class ASGSize(credentials: AWSCredentials) extends AWSRestartableActor with AmazonAutoScalingService {
+class ASGSize(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonAutoScalingService {
 
   import actors.workflow.tasks.ASGSize._
 

--- a/app/actors/workflow/tasks/DeleteStack.scala
+++ b/app/actors/workflow/tasks/DeleteStack.scala
@@ -2,11 +2,11 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.model.DeleteStackRequest
 import utils.{AmazonCloudFormationService, PropFactory}
 
-class DeleteStack(credentials: AWSCredentials) extends AWSRestartableActor with AmazonCloudFormationService {
+class DeleteStack(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonCloudFormationService {
 
   import actors.workflow.tasks.DeleteStack._
 

--- a/app/actors/workflow/tasks/ELBHealthyInstanceChecker.scala
+++ b/app/actors/workflow/tasks/ELBHealthyInstanceChecker.scala
@@ -2,13 +2,13 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, Instance}
 import utils.{AmazonElasticLoadBalancingService, PropFactory}
 
 import scala.collection.JavaConverters._
 
-class ELBHealthyInstanceChecker(credentials: AWSCredentials) extends AWSRestartableActor
+class ELBHealthyInstanceChecker(credentials: AWSCredentialsProvider) extends AWSRestartableActor
                                                                      with AmazonElasticLoadBalancingService {
 
   import actors.workflow.tasks.ELBHealthyInstanceChecker._

--- a/app/actors/workflow/tasks/FreezeASG.scala
+++ b/app/actors/workflow/tasks/FreezeASG.scala
@@ -2,13 +2,13 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.model.SuspendProcessesRequest
 import utils.{AmazonAutoScalingService, PropFactory}
 
 import scala.collection.JavaConverters._
 
-class FreezeASG(credentials: AWSCredentials) extends AWSRestartableActor with AmazonAutoScalingService {
+class FreezeASG(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonAutoScalingService {
 
   import actors.workflow.tasks.FreezeASG._
 

--- a/app/actors/workflow/tasks/StackCreateCompleteMonitor.scala
+++ b/app/actors/workflow/tasks/StackCreateCompleteMonitor.scala
@@ -3,7 +3,7 @@ package actors.workflow.tasks
 import actors.WorkflowLog.LogMessage
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
 import play.api.Logger
 import utils.{AmazonCloudFormationService, PropFactory}
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 
-class StackCreateCompleteMonitor(credentials: AWSCredentials, stackName: String) extends AWSRestartableActor
+class StackCreateCompleteMonitor(credentials: AWSCredentialsProvider, stackName: String) extends AWSRestartableActor
                                                                                          with AmazonCloudFormationService {
 
   import actors.workflow.tasks.StackCreateCompleteMonitor._

--- a/app/actors/workflow/tasks/StackCreator.scala
+++ b/app/actors/workflow/tasks/StackCreator.scala
@@ -3,12 +3,12 @@ package actors.workflow.tasks
 import actors.DeploymentSupervisor.{StackAndAppVersion, AppVersion, Version}
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.model.{Capability, CreateStackRequest, Parameter, Tag}
 import play.api.libs.json.JsValue
 import utils.{AmazonCloudFormationService, PropFactory}
 
-class StackCreator(credentials: AWSCredentials) extends AWSRestartableActor with AmazonCloudFormationService {
+class StackCreator(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonCloudFormationService {
 
   import actors.workflow.tasks.StackCreator._
 

--- a/app/actors/workflow/tasks/StackDeleteCompleteMonitor.scala
+++ b/app/actors/workflow/tasks/StackDeleteCompleteMonitor.scala
@@ -3,7 +3,7 @@ package actors.workflow.tasks
 import actors.WorkflowLog.LogMessage
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
 import utils.{AmazonCloudFormationService, PropFactory}
 
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class StackDeleteCompleteMonitor(credentials: AWSCredentials, stackId: String,
+class StackDeleteCompleteMonitor(credentials: AWSCredentialsProvider, stackId: String,
                                  stackName: String) extends AWSRestartableActor with AmazonCloudFormationService {
 
   import actors.workflow.tasks.StackDeleteCompleteMonitor._

--- a/app/actors/workflow/tasks/StackInfo.scala
+++ b/app/actors/workflow/tasks/StackInfo.scala
@@ -2,13 +2,13 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
 import utils.{AmazonCloudFormationService, PropFactory}
 
 import scala.collection.JavaConverters._
 
-class StackInfo(credentials: AWSCredentials) extends AWSRestartableActor with AmazonCloudFormationService {
+class StackInfo(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonCloudFormationService {
 
   import actors.workflow.tasks.StackInfo._
 

--- a/app/actors/workflow/tasks/StackList.scala
+++ b/app/actors/workflow/tasks/StackList.scala
@@ -2,7 +2,7 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{StackSummary, ListStacksRequest}
 import com.amazonaws.services.cloudformation.model.StackStatus._
@@ -11,7 +11,7 @@ import utils.{AmazonCloudFormationService, PropFactory}
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-class StackList(credentials: AWSCredentials) extends AWSRestartableActor with AmazonCloudFormationService {
+class StackList(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonCloudFormationService {
 
   import actors.workflow.tasks.StackList._
 

--- a/app/actors/workflow/tasks/StackLoader.scala
+++ b/app/actors/workflow/tasks/StackLoader.scala
@@ -2,7 +2,7 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.S3Object
 import org.apache.commons.io.IOUtils
@@ -10,7 +10,7 @@ import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import utils.{AmazonS3Service, PropFactory}
 
-class StackLoader(credentials: AWSCredentials, bucketName: String) extends AWSRestartableActor with AmazonS3Service {
+class StackLoader(credentials: AWSCredentialsProvider, bucketName: String) extends AWSRestartableActor with AmazonS3Service {
 
   import actors.workflow.tasks.StackLoader._
 

--- a/app/actors/workflow/tasks/UnfreezeASG.scala
+++ b/app/actors/workflow/tasks/UnfreezeASG.scala
@@ -2,12 +2,12 @@ package actors.workflow.tasks
 
 import actors.workflow.AWSRestartableActor
 import akka.actor.{Actor, ActorLogging, Props}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.ResumeProcessesRequest
 import utils.{AmazonAutoScalingService, PropFactory}
 
-class UnfreezeASG(credentials: AWSCredentials) extends AWSRestartableActor with AmazonAutoScalingService {
+class UnfreezeASG(credentials: AWSCredentialsProvider) extends AWSRestartableActor with AmazonAutoScalingService {
 
   import actors.workflow.tasks.UnfreezeASG._
 

--- a/app/utils/Components.scala
+++ b/app/utils/Components.scala
@@ -1,23 +1,23 @@
 package utils
 
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClient}
 import com.amazonaws.services.cloudformation.{AmazonCloudFormation, AmazonCloudFormationClient}
 import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing, AmazonElasticLoadBalancingClient}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 
 trait AmazonAutoScalingService {
-  def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = new AmazonAutoScalingClient(credentials)
+  def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = new AmazonAutoScalingClient(credentials)
 }
 
 trait AmazonCloudFormationService {
-  def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = new AmazonCloudFormationClient(credentials)
+  def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = new AmazonCloudFormationClient(credentials)
 }
 
 trait AmazonElasticLoadBalancingService {
-  def elasticLoadBalancingClient(credentials: AWSCredentials): AmazonElasticLoadBalancing = new AmazonElasticLoadBalancingClient(credentials)
+  def elasticLoadBalancingClient(credentials: AWSCredentialsProvider): AmazonElasticLoadBalancing = new AmazonElasticLoadBalancingClient(credentials)
 }
 
 trait AmazonS3Service {
-  def s3Client(credentials: AWSCredentials): AmazonS3 = new AmazonS3Client(credentials)
+  def s3Client(credentials: AWSCredentialsProvider): AmazonS3 = new AmazonS3Client(credentials)
 }

--- a/test/actors/workflow/tasks/ASGInfoSpec.scala
+++ b/test/actors/workflow/tasks/ASGInfoSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.ASGInfo.{ASGInServiceInstancesAndELBSQuery, ASGInServiceInstancesAndELBSResult}
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model._
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -58,7 +58,7 @@ class ASGInfoSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testC
   val asgInfoProps = Props(new ASGInfo(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+    override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/ASGSizeSpec.scala
+++ b/test/actors/workflow/tasks/ASGSizeSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.ASGSize._
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, DescribeAutoScalingGroupsRequest, DescribeAutoScalingGroupsResult, SetDesiredCapacityRequest}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -69,7 +69,7 @@ class ASGSizeSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testC
   val props = Props(new ASGSize(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+    override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/DeleteStackSpec.scala
+++ b/test/actors/workflow/tasks/DeleteStackSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.DeleteStack.{DeleteStackCommand, StackDeleteRequested}
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.DeleteStackRequest
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -57,7 +57,7 @@ class DeleteStackSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
   val props = Props(new DeleteStack(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/ELBHealthInstanceCheckerSpec.scala
+++ b/test/actors/workflow/tasks/ELBHealthInstanceCheckerSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.ELBHealthyInstanceChecker.{ELBInstanceListAllHealthy, ELBInstanceListNotHealthy, ELBIsInstanceListHealthy}
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, Instance, InstanceState}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -72,7 +72,7 @@ class ELBHealthInstanceCheckerSpec extends TestKit(ActorSystem("TestKit", TestCo
   val props = Props(new ELBHealthyInstanceChecker(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def elasticLoadBalancingClient(credentials: AWSCredentials) = mockedClient
+    override def elasticLoadBalancingClient(credentials: AWSCredentialsProvider) = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/FreezeASGSpec.scala
+++ b/test/actors/workflow/tasks/FreezeASGSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.FreezeASG.{FreezeASGCommand, FreezeASGCompleted}
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.SuspendProcessesRequest
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -59,7 +59,7 @@ class FreezeASGSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.tes
   val props = Props(new FreezeASG(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+    override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/StackCreateCompleteMonitorSpec.scala
+++ b/test/actors/workflow/tasks/StackCreateCompleteMonitorSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackCreateCompleteMonitor.{StackCreateCompleted, Tick}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack, StackStatus}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -118,7 +118,7 @@ class StackCreateCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", Test
     this: StackCreateCompleteMonitor =>
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
     override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, Tick)
   }

--- a/test/actors/workflow/tasks/StackCreatorSpec.scala
+++ b/test/actors/workflow/tasks/StackCreatorSpec.scala
@@ -5,7 +5,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackCreator.{StackCreateCommand, StackCreateRequestCompleted}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{Capability, CreateStackRequest, Parameter, Tag}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -65,7 +65,7 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
   val props = Props(new StackCreator(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/StackDeleteCompleteMonitorSpec.scala
+++ b/test/actors/workflow/tasks/StackDeleteCompleteMonitorSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackDeleteCompleteMonitor.{StackDeleteCompleted, Tick}
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack, StackStatus}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -116,7 +116,7 @@ class StackDeleteCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", Test
     this: StackDeleteCompleteMonitor =>
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
     override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, Tick)
   }

--- a/test/actors/workflow/tasks/StackInfoSpec.scala
+++ b/test/actors/workflow/tasks/StackInfoSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackInfo.{StackASGNameQuery, StackASGNameResponse, StackIdQuery, StackIdResponse}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Output, Stack}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -71,7 +71,7 @@ class StackInfoSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.tes
   val props = Props(new StackInfo(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/StackListSpec.scala
+++ b/test/actors/workflow/tasks/StackListSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackList.{FilteredStacks, ListNonDeletedStacksStartingWithName}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.StackStatus._
 import com.amazonaws.services.cloudformation.model.{ListStacksRequest, ListStacksResult, StackSummary}
@@ -60,13 +60,13 @@ class StackListSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.tes
   val props = Props(new StackList(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
   })
 
   val failProps = Props(new StackList(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = failMockedClient
+    override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = failMockedClient
   })
 
   class TestActorFactory(prop: Props) extends ActorFactory {

--- a/test/actors/workflow/tasks/StackLoaderSpec.scala
+++ b/test/actors/workflow/tasks/StackLoaderSpec.scala
@@ -6,7 +6,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.StackLoader.{LoadStack, StackLoaded}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -64,7 +64,7 @@ class StackLoaderSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
   val props = Props(new StackLoader(null, "test-bucket-name") {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def s3Client(credentials: AWSCredentials): AmazonS3 = mockedClient
+    override def s3Client(credentials: AWSCredentialsProvider): AmazonS3 = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/actors/workflow/tasks/UnfreezeASGSpec.scala
+++ b/test/actors/workflow/tasks/UnfreezeASGSpec.scala
@@ -4,7 +4,7 @@ import actors.WorkflowLog.LogMessage
 import actors.workflow.tasks.UnfreezeASG.{UnfreezeASGCommand, UnfreezeASGCompleted}
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.ResumeProcessesRequest
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -57,7 +57,7 @@ class UnfreezeASGSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
   val props = Props(new UnfreezeASG(null) {
     override def pauseTime(): FiniteDuration = 5.milliseconds
 
-    override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+    override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
   })
 
   object TestActorFactory extends ActorFactory {

--- a/test/functional/WorkflowManagerSystemTest.scala
+++ b/test/functional/WorkflowManagerSystemTest.scala
@@ -10,7 +10,7 @@ import actors.workflow.tasks.StackCreateCompleteMonitor.Tick
 import actors.workflow.tasks._
 import akka.actor._
 import akka.testkit.{TestKit, TestProbe}
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model._
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
@@ -274,7 +274,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackLoader(null, "test-bucket-name") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def s3Client(credentials: AWSCredentials): AmazonS3 = mockedClient
+        override def s3Client(credentials: AWSCredentialsProvider): AmazonS3 = mockedClient
       })
     }
 
@@ -291,7 +291,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackList(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
       })
     }
 
@@ -332,7 +332,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackCreator(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
       })
     }
 
@@ -353,7 +353,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackCreateCompleteMonitor(null, "chadash-newstack-somename-v1-0") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, Tick)
       })
@@ -361,7 +361,7 @@ object WorkflowManagerSystemTest {
       val updateProps = Props(new StackCreateCompleteMonitor(null, "chadash-updatestack-somename-sv20-av1-1") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, Tick)
       })
@@ -369,7 +369,7 @@ object WorkflowManagerSystemTest {
       val growProps = Props(new StackCreateCompleteMonitor(null, "chadash-updatestack-growstack-v1-2") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, Tick)
       })
@@ -422,7 +422,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackInfo(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
       })
     }
 
@@ -443,7 +443,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new FreezeASG(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+        override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
       })
     }
 
@@ -477,7 +477,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new ASGSize(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+        override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
       })
     }
 
@@ -508,7 +508,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new ASGInfo(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+        override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
       })
     }
 
@@ -535,7 +535,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new ELBHealthyInstanceChecker(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def elasticLoadBalancingClient(credentials: AWSCredentials) = mockedClient
+        override def elasticLoadBalancingClient(credentials: AWSCredentialsProvider) = mockedClient
       })
     }
 
@@ -556,7 +556,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new StackDeleteCompleteMonitor(null, "some-stack-id", "chadash-newstack-somename-v1-0") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, actors.workflow.tasks.StackDeleteCompleteMonitor.Tick)
       })
@@ -564,7 +564,7 @@ object WorkflowManagerSystemTest {
       val growProps = Props(new StackDeleteCompleteMonitor(null, "some-growstack-id", "chadash-newstack-growstack-v1-1") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, actors.workflow.tasks.StackDeleteCompleteMonitor.Tick)
       })
@@ -572,7 +572,7 @@ object WorkflowManagerSystemTest {
       val deleteStack = Props(new StackDeleteCompleteMonitor(null, "delete-stack-id", "chadash-updatestack-somename-v1-2") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
 
         override def scheduleTick() = context.system.scheduler.scheduleOnce(5.milliseconds, self, actors.workflow.tasks.StackDeleteCompleteMonitor.Tick)
       })
@@ -590,7 +590,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new UnfreezeASG(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def autoScalingClient(credentials: AWSCredentials): AmazonAutoScaling = mockedClient
+        override def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = mockedClient
       })
     }
 
@@ -608,7 +608,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new DeleteStack(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
       })
     }
 
@@ -623,7 +623,7 @@ object WorkflowManagerSystemTest {
       val props = Props(new actors.workflow.tasks.StackList(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
 
-        override def cloudFormationClient(credentials: AWSCredentials): AmazonCloudFormation = mockedClient
+        override def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = mockedClient
       })
     }
   }


### PR DESCRIPTION
The InstanceProfileCredentials provider in the SDK knows when to automatically refresh to get the next credential set when getCredentials is called. The whole idea of having akka do this for us with a 30 minute refresh was a bad idea since the SDK handles all the edge cases for you. This PR switches that actor around so it provides a credential provider instead of the credentials itself. 

By passing the CredentialsProvider around, the correct / refreshed credentials should be provided automatically by AWS's SDK every time.
