### PR TITLE
New feature: Support Stack Tags as a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ To do this we've authored an overly simple app that makes the API call for your 
 
 This software is licensed under the Apache 2 license, quoted below.
 
-Copyright (C) 2014-2016 LifeWay Christian Resources. (https://www.lifeway.com).
+Copyright (C) 2014-2018 LifeWay Christian Resources. (https://www.lifeway.com).
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 

--- a/app/actors/workflow/AmazonCredentials.scala
+++ b/app/actors/workflow/AmazonCredentials.scala
@@ -52,7 +52,7 @@ class AmazonCredentials extends Actor with ActorLogging {
       val provider: AWSCredentialsProvider = credentialsProvider match {
         case "DefaultAWSCredentialsProviderChain" => new DefaultAWSCredentialsProviderChain()
         case "TypesafeConfigAWSCredentialsProvider" => new TypesafeConfigAWSCredentialsProvider(config)
-        case "InstanceProfileCredentialsProvider" => new InstanceProfileCredentialsProvider()
+        case "InstanceProfileCredentialsProvider" => InstanceProfileCredentialsProvider.getInstance()
         case "ClasspathPropertiesFileCredentialsProvider" => new ClasspathPropertiesFileCredentialsProvider()
         case "EnvironmentVariableCredentialsProvider" => new EnvironmentVariableCredentialsProvider()
         case "SystemPropertiesCredentialsProvider" => new SystemPropertiesCredentialsProvider()

--- a/app/actors/workflow/steps/NewStackSupervisor.scala
+++ b/app/actors/workflow/steps/NewStackSupervisor.scala
@@ -28,13 +28,13 @@ class NewStackSupervisor(credentials: AWSCredentialsProvider,
     case Event(msg: NewStackFirstLaunchCommand, Uninitialized) =>
       val stackCreator = actorFactory(StackCreator, context, "stackLauncher", credentials)
       context.watch(stackCreator)
-      stackCreator ! StackCreateCommand(msg.newStackName, msg.imageId, msg.version, msg.stackContent)
+      stackCreator ! StackCreateCommand(msg.newStackName, msg.imageId, msg.version, msg.stackContent, msg.tags)
       goto(AwaitingStackCreatedResponse) using FirstTimeStack(msg.newStackName)
 
     case Event(msg: NewStackUpgradeLaunchCommand, Uninitialized) =>
       val stackCreator = actorFactory(StackCreator, context, "stackLauncher", credentials)
       context.watch(stackCreator)
-      stackCreator ! StackCreateCommand(msg.newStackName, msg.imageId, msg.version, msg.stackContent)
+      stackCreator ! StackCreateCommand(msg.newStackName, msg.imageId, msg.version, msg.stackContent, msg.tags)
       goto(AwaitingStackCreatedResponse) using UpgradeOldStackData(msg.oldStackASG, msg.oldStackName, msg.newStackName)
   }
 
@@ -176,8 +176,8 @@ object NewStackSupervisor extends PropFactory {
   //Interaction Messages
   sealed trait NewStackMessage
   case class NewStackFirstLaunchCommand(newStackName: String, imageId: String, version: Version,
-                                        stackContent: JsValue) extends NewStackMessage
-  case class NewStackUpgradeLaunchCommand(newStackName: String, imageId: String, version: Version, stackContent: JsValue,
+                                        stackContent: JsValue, tags: Option[Seq[Tag]]) extends NewStackMessage
+  case class NewStackUpgradeLaunchCommand(newStackName: String, imageId: String, version: Version, stackContent: JsValue, tags: Option[Seq[Tag]],
                                           oldStackName: String, oldStackASG: String) extends NewStackMessage
   case class FirstStackLaunchCompleted(newStackName: String) extends NewStackMessage
   case class StackUpgradeLaunchCompleted(newAsgName: String) extends NewStackMessage

--- a/app/actors/workflow/tasks/StackLoader.scala
+++ b/app/actors/workflow/tasks/StackLoader.scala
@@ -3,12 +3,25 @@ package actors.workflow.tasks
 import actors.workflow.AWSRestartableActor
 import akka.actor.Props
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{AmazonS3Exception, S3Object}
 import org.apache.commons.io.IOUtils
-import play.api.Logger
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 import utils.{AmazonS3Service, PropFactory}
+
+case class Tag(key: String, value: String)
+
+object Tag {
+  implicit val reads: Reads[Tag] = (
+    (JsPath \ "Key").read[String] and
+      (JsPath \ "Value").read[String]
+  )(Tag.apply _)
+  implicit val writes: Writes[Tag] = (
+    (JsPath \ "Key").write[String] and
+      (JsPath \ "Value").write[String]
+  )(unlift(Tag.unapply))
+}
 
 class StackLoader(credentials: AWSCredentialsProvider, bucketName: String) extends AWSRestartableActor with AmazonS3Service {
 
@@ -18,15 +31,26 @@ class StackLoader(credentials: AWSCredentialsProvider, bucketName: String) exten
     case msg: LoadStack =>
       val client = s3Client(credentials)
       val stackObject: S3Object = client.getObject(bucketName, s"chadash-stacks/${msg.stackPath}.json")
+      val tags = getTags(bucketName, s"chadash-stacks/${msg.stackPath}.tags.json", client)
       val stackFileJson = Json.parse(IOUtils.toByteArray(stackObject.getObjectContent))
 
-      context.parent ! StackLoaded(stackFileJson)
+      context.parent ! StackLoaded(stackFileJson, tags)
+  }
+
+  def getTags(bucketName: String, path: String, client: AmazonS3): Option[Seq[Tag]] = {
+    try {
+      val tagObject: S3Object = client.getObject(bucketName, path)
+      Json.parse(IOUtils.toByteArray(tagObject.getObjectContent)).asOpt[Seq[Tag]]
+    } catch {
+      case _:AmazonS3Exception => None
+      case e:Throwable => throw e
+    }
   }
 }
 
 object StackLoader extends PropFactory {
   case class LoadStack(stackPath: String)
-  case class StackLoaded(stackJson: JsValue)
+  case class StackLoaded(stackJson: JsValue, tags: Option[Seq[Tag]])
 
   override def props(args: Any*): Props = Props(classOf[StackLoader], args: _*)
 }

--- a/app/utils/Components.scala
+++ b/app/utils/Components.scala
@@ -1,23 +1,23 @@
 package utils
 
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClient}
-import com.amazonaws.services.cloudformation.{AmazonCloudFormation, AmazonCloudFormationClient}
-import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing, AmazonElasticLoadBalancingClient}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
+import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormation, AmazonCloudFormationClientBuilder}
+import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing, AmazonElasticLoadBalancingClientBuilder}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 
 trait AmazonAutoScalingService {
-  def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = new AmazonAutoScalingClient(credentials)
+  def autoScalingClient(credentials: AWSCredentialsProvider): AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard().withCredentials(credentials).build()
 }
 
 trait AmazonCloudFormationService {
-  def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = new AmazonCloudFormationClient(credentials)
+  def cloudFormationClient(credentials: AWSCredentialsProvider): AmazonCloudFormation = AmazonCloudFormationClientBuilder.standard().withCredentials(credentials).build()
 }
 
 trait AmazonElasticLoadBalancingService {
-  def elasticLoadBalancingClient(credentials: AWSCredentialsProvider): AmazonElasticLoadBalancing = new AmazonElasticLoadBalancingClient(credentials)
+  def elasticLoadBalancingClient(credentials: AWSCredentialsProvider): AmazonElasticLoadBalancing = AmazonElasticLoadBalancingClientBuilder.standard().withCredentials(credentials).build()
 }
 
 trait AmazonS3Service {
-  def s3Client(credentials: AWSCredentialsProvider): AmazonS3 = new AmazonS3Client(credentials)
+  def s3Client(credentials: AWSCredentialsProvider): AmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(credentials).build()
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,20 +7,29 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala).settings(
   javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
   //FOR DEBUGGING TESTS:
   //,javaOptions in Test += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9999"
-)
+).settings(libraryDependencies ~= (_.map(excludeSpecs2)))
+val AwsVersion   = "1.11.298"
 
 libraryDependencies ++= Seq(
   ws,
   filters,
-  "com.amazonaws" % "aws-java-sdk" % "1.9.19",
+  "com.amazonaws" % "aws-java-sdk-cloudformation" % AwsVersion,
+  "com.amazonaws" % "aws-java-sdk-s3" % AwsVersion,
+  "com.amazonaws" % "aws-java-sdk-autoscaling" % AwsVersion,
+  "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % AwsVersion,
   "com.google.code.findbugs" % "jsr305" % "3.0.0",
   "commons-io" % "commons-io" % "2.4",
   "com.typesafe.akka" %% "akka-actor" % "2.3.9",
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.9",
   "com.typesafe.akka" %% "akka-testkit" % "2.3.9" % "test",
-  "org.scalatestplus" %% "play" % "1.1.0" % "test",
+  "org.scalatestplus" %% "play" % "1.2.0" % "test",
+  "org.mockito" % "mockito-core" % "2.16.0" % "test",
   "com.google.inject" % "guice" % "3.0"
 )
+
+def excludeSpecs2(module: ModuleID): ModuleID =
+  module.excludeAll(ExclusionRule(organization =
+    "org.specs2")).exclude("com.novocode", "junit-interface")
 
 //----
 // Create the buildInfo object at compile time

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "chadash"
 version := scala.util.Properties.envOrElse("BUILD_VERSION", "DEV")
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.12"
 scalacOptions ++= Seq("-feature", "-target:jvm-1.8")
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala).settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,1 @@
-#Activator-generated Properties
-#Sat Sep 13 08:19:33 CDT 2014
-template.uuid=9d0f021d-ca8f-4a88-992f-f6468442419e
-sbt.version=0.13.8
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
 

--- a/test/actors/workflow/tasks/ASGInfoSpec.scala
+++ b/test/actors/workflow/tasks/ASGInfoSpec.scala
@@ -9,16 +9,15 @@ import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model._
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils._
 
 import scala.concurrent.duration._
 
 class ASGInfoSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike with Matchers
-                          with MockitoSugar with BeforeAndAfterAll {
+               with BeforeAndAfterAll {
 
-  val mockedClient            = mock[AmazonAutoScaling]
+  val mockedClient            = Mockito.mock(classOf[AmazonAutoScaling])
   val describeASGRequest      = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames("test-asg-name")
   val describeASGReqFail      = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames("expect-fail")
   val describeASGReqClientExc = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames("client-exception")

--- a/test/actors/workflow/tasks/ELBHealthInstanceCheckerSpec.scala
+++ b/test/actors/workflow/tasks/ELBHealthInstanceCheckerSpec.scala
@@ -9,16 +9,15 @@ import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, Instance, InstanceState}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
 
 import scala.concurrent.duration._
 
 class ELBHealthInstanceCheckerSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig))
-                                           with FlatSpecLike with Matchers with MockitoSugar with BeforeAndAfterAll {
+                                           with FlatSpecLike with Matchers with BeforeAndAfterAll {
 
-  val mockedClient             = mock[AmazonElasticLoadBalancing]
+  val mockedClient             = Mockito.mock(classOf[AmazonElasticLoadBalancing])
   val instance                 = new Instance("instance-1")
   val instancesNotAllHealthy   = Seq(instance, new Instance("instance-2"), new Instance("instance-3"))
   val instanceStates           = new InstanceState().withState("InService")

--- a/test/actors/workflow/tasks/StackCreateCompleteMonitorSpec.scala
+++ b/test/actors/workflow/tasks/StackCreateCompleteMonitorSpec.scala
@@ -8,7 +8,7 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack, StackStatus}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
-import org.mockito.Mockito
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
@@ -17,9 +17,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class StackCreateCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig))
-                                             with FlatSpecLike with Matchers with MockitoSugar with BeforeAndAfterAll {
+                                             with FlatSpecLike with Matchers with BeforeAndAfterAll {
 
-  val mockedClient       = mock[AmazonCloudFormation]
+  val mockedClient       = Mockito.mock(classOf[AmazonCloudFormation])
   val createCompleteReq  = new DescribeStacksRequest().withStackName("create-completed")
   val createCompleteReq2 = new DescribeStacksRequest().withStackName("create-completed-2")
   val stackFailReq       = new DescribeStacksRequest().withStackName("stack-fail")
@@ -36,12 +36,13 @@ class StackCreateCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", Test
   val stackBadStatusResp = new DescribeStacksResult().withStacks(stackBadStatus)
 
 
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(createCompleteReq)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(createCompleteReq2)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackFailedResp).when(mockedClient).describeStacks(stackFailReq)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackBadStatusResp).when(mockedClient).describeStacks(stackBadTypeReq)
+  Mockito.doThrow(new IllegalArgumentException).when(mockedClient).describeStacks(ArgumentMatchers.any())
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(createCompleteReq)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(createCompleteReq2)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackFailedResp, Nil: _*).when(mockedClient).describeStacks(stackFailReq)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackBadStatusResp, Nil: _*).when(mockedClient).describeStacks(stackBadTypeReq)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).describeStacks(awsFailReq)
-  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(clientExceptionReq)
+  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(clientExceptionReq)
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/test/actors/workflow/tasks/StackCreatorSpec.scala
+++ b/test/actors/workflow/tasks/StackCreatorSpec.scala
@@ -10,8 +10,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{Capability, CreateStackRequest, Parameter}
 import com.amazonaws.services.cloudformation.model.{Tag => AWSTag}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
-import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import play.api.libs.json.Json
 import utils.{ActorFactory, PropFactory, TestConfiguration}
@@ -19,9 +18,9 @@ import utils.{ActorFactory, PropFactory, TestConfiguration}
 import scala.concurrent.duration._
 
 class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike
-                               with Matchers with MockitoSugar with BeforeAndAfterAll {
+                               with Matchers with BeforeAndAfterAll {
 
-  val mockedClient  = mock[AmazonCloudFormation]
+  val mockedClient  = Mockito.mock(classOf[AmazonCloudFormation])
   val appVersionTag = new AWSTag().withKey("ApplicationVersion").withValue("1.0")
   val projectTag = new AWSTag().withKey("Project").withValue("Chadash")
   val params        = Seq(
@@ -34,11 +33,11 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
   val reqClientExc  = new CreateStackRequest().withTemplateBody(Json.obj("someObject" -> "someBody").toString()).withTags(appVersionTag).withParameters(params: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("client-exception")
 
   //If we don't check Mock data response, we must have throw an exception if we didn't match the request.
-  Mockito.doThrow(new IllegalArgumentException).when(mockedClient).createStack(org.mockito.Matchers.anyObject())
-  Mockito.doReturn(null).when(mockedClient).createStack(successReq)
-  Mockito.doReturn(null).when(mockedClient).createStack(successReqWithTags)
+  Mockito.doThrow(new IllegalArgumentException).when(mockedClient).createStack(ArgumentMatchers.any())
+  Mockito.doReturn(null, Nil: _*).when(mockedClient).createStack(successReq)
+  Mockito.doReturn(null, Nil: _*).when(mockedClient).createStack(successReqWithTags)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).createStack(reqFail)
-  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(null).when(mockedClient).createStack(reqClientExc)
+  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(null, Nil: _*).when(mockedClient).createStack(reqClientExc)
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/test/actors/workflow/tasks/StackCreatorSpec.scala
+++ b/test/actors/workflow/tasks/StackCreatorSpec.scala
@@ -7,7 +7,8 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormation
-import com.amazonaws.services.cloudformation.model.{Capability, CreateStackRequest, Parameter, Tag}
+import com.amazonaws.services.cloudformation.model.{Capability, CreateStackRequest, Parameter}
+import com.amazonaws.services.cloudformation.model.{Tag => AWSTag}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
 import org.scalatest.mock.MockitoSugar
@@ -21,18 +22,21 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
                                with Matchers with MockitoSugar with BeforeAndAfterAll {
 
   val mockedClient  = mock[AmazonCloudFormation]
-  val appVersionTag = new Tag().withKey("ApplicationVersion").withValue("1.0")
+  val appVersionTag = new AWSTag().withKey("ApplicationVersion").withValue("1.0")
+  val projectTag = new AWSTag().withKey("Project").withValue("Chadash")
   val params        = Seq(
     new Parameter().withParameterKey("ImageId").withParameterValue("image-id"),
     new Parameter().withParameterKey("ApplicationVersion").withParameterValue("1.0")
   )
   val successReq    = new CreateStackRequest().withTemplateBody(Json.obj("someObject" -> "someBody").toString()).withTags(appVersionTag).withParameters(params: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("success-stack")
+  val successReqWithTags = new CreateStackRequest().withTemplateBody(Json.obj("someObject" -> "someBody").toString()).withTags(appVersionTag, projectTag).withParameters(params: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("success-stack")
   val reqFail       = new CreateStackRequest().withTemplateBody(Json.obj("someObject" -> "someBody").toString()).withTags(appVersionTag).withParameters(params: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("fail-stack")
   val reqClientExc  = new CreateStackRequest().withTemplateBody(Json.obj("someObject" -> "someBody").toString()).withTags(appVersionTag).withParameters(params: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("client-exception")
 
   //If we don't check Mock data response, we must have throw an exception if we didn't match the request.
   Mockito.doThrow(new IllegalArgumentException).when(mockedClient).createStack(org.mockito.Matchers.anyObject())
   Mockito.doReturn(null).when(mockedClient).createStack(successReq)
+  Mockito.doReturn(null).when(mockedClient).createStack(successReqWithTags)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).createStack(reqFail)
   Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(null).when(mockedClient).createStack(reqClientExc)
 
@@ -44,7 +48,15 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
     val probe = TestProbe()
     val proxy = TaskProxyBuilder(probe, StackCreator, system, TestActorFactory)
 
-    probe.send(proxy, StackCreateCommand("success-stack", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody")))
+    probe.send(proxy, StackCreateCommand("success-stack", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody"), None))
+    probe.expectMsg(StackCreateRequestCompleted)
+  }
+
+  it should "return a stack create request completed if successful with tags" in {
+    val probe = TestProbe()
+    val proxy = TaskProxyBuilder(probe, StackCreator, system, TestActorFactory)
+
+    probe.send(proxy, StackCreateCommand("success-stack", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody"), Some(Seq(Tag("Project", "Chadash")))))
     probe.expectMsg(StackCreateRequestCompleted)
   }
 
@@ -52,7 +64,7 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
     val probe = TestProbe()
     val proxy = TaskProxyBuilder(probe, StackCreator, system, TestActorFactory)
 
-    probe.send(proxy, StackCreateCommand("fail-stack", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody")))
+    probe.send(proxy, StackCreateCommand("fail-stack", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody"), None))
     val msg = probe.expectMsgClass(classOf[LogMessage])
     msg.message should include("AmazonServiceException")
   }
@@ -61,7 +73,7 @@ class StackCreatorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.
     val probe = TestProbe()
     val proxy = TaskProxyBuilder(probe, StackCreator, system, TestActorFactory)
 
-    probe.send(proxy, StackCreateCommand("client-exception", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody")))
+    probe.send(proxy, StackCreateCommand("client-exception", "image-id", DeploymentSupervisor.buildVersion("1.0"), Json.obj("someObject" -> "someBody"), None))
     probe.expectMsg(StackCreateRequestCompleted)
   }
 

--- a/test/actors/workflow/tasks/StackDeleteCompleteMonitorSpec.scala
+++ b/test/actors/workflow/tasks/StackDeleteCompleteMonitorSpec.scala
@@ -9,7 +9,6 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack, StackStatus}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
 
@@ -17,9 +16,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class StackDeleteCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig))
-                                             with FlatSpecLike with Matchers with MockitoSugar with BeforeAndAfterAll {
+                                             with FlatSpecLike with Matchers with BeforeAndAfterAll {
 
-  val mockedClient       = mock[AmazonCloudFormation]
+  val mockedClient       = Mockito.mock(classOf[AmazonCloudFormation])
   val deleteCompleteReq  = new DescribeStacksRequest().withStackName("delete-completed")
   val deleteCompleteReq2 = new DescribeStacksRequest().withStackName("delete-completed-2")
   val stackFailReq       = new DescribeStacksRequest().withStackName("stack-fail")
@@ -35,12 +34,12 @@ class StackDeleteCompleteMonitorSpec extends TestKit(ActorSystem("TestKit", Test
   val stackFailedResp    = new DescribeStacksResult().withStacks(stackFailed)
   val stackBadStatusResp = new DescribeStacksResult().withStacks(stackBadStatus)
 
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(deleteCompleteReq)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(deleteCompleteReq2)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackFailedResp).when(mockedClient).describeStacks(stackFailReq)
-  Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackBadStatusResp).when(mockedClient).describeStacks(stackBadTypeReq)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(deleteCompleteReq)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(deleteCompleteReq2)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackFailedResp, Nil: _*).when(mockedClient).describeStacks(stackFailReq)
+  Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackBadStatusResp, Nil: _*).when(mockedClient).describeStacks(stackBadTypeReq)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).describeStacks(awsFailReq)
-  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(clientExceptionReq)
+  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(clientExceptionReq)
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/test/actors/workflow/tasks/StackInfoSpec.scala
+++ b/test/actors/workflow/tasks/StackInfoSpec.scala
@@ -9,16 +9,15 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Output, Stack}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
 
 import scala.concurrent.duration._
 
 class StackInfoSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike
-                            with Matchers with MockitoSugar with BeforeAndAfterAll {
+                            with Matchers with BeforeAndAfterAll {
 
-  val mockedClient       = mock[AmazonCloudFormation]
+  val mockedClient       = Mockito.mock(classOf[AmazonCloudFormation])
   val asgSuccessReq      = new DescribeStacksRequest().withStackName("asg-name-query")
   val idSuccessReq       = new DescribeStacksRequest().withStackName("stack-id-query")
   val failReq            = new DescribeStacksRequest().withStackName("expect-fail")
@@ -30,10 +29,10 @@ class StackInfoSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.tes
   val idSuccessResult    = new DescribeStacksResult().withStacks(idStack)
 
 
-  Mockito.doReturn(asgSuccessResult).when(mockedClient).describeStacks(asgSuccessReq)
-  Mockito.doReturn(idSuccessResult).when(mockedClient).describeStacks(idSuccessReq)
+  Mockito.doReturn(asgSuccessResult, Nil: _*).when(mockedClient).describeStacks(asgSuccessReq)
+  Mockito.doReturn(idSuccessResult, Nil: _*).when(mockedClient).describeStacks(idSuccessReq)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).describeStacks(failReq)
-  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(idSuccessResult).when(mockedClient).describeStacks(clientExceptionReq)
+  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(idSuccessResult, Nil: _*).when(mockedClient).describeStacks(clientExceptionReq)
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/test/actors/workflow/tasks/StackListSpec.scala
+++ b/test/actors/workflow/tasks/StackListSpec.scala
@@ -10,25 +10,24 @@ import com.amazonaws.services.cloudformation.model.StackStatus._
 import com.amazonaws.services.cloudformation.model.{ListStacksRequest, ListStacksResult, StackSummary}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
 
 import scala.concurrent.duration._
 
 class StackListSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike
-                            with Matchers with MockitoSugar with BeforeAndAfterAll {
+                            with Matchers with BeforeAndAfterAll {
 
-  val mockedClient          = mock[AmazonCloudFormation]
-  val failMockedClient      = mock[AmazonCloudFormation]
+  val mockedClient          = Mockito.mock(classOf[AmazonCloudFormation])
+  val failMockedClient      = Mockito.mock(classOf[AmazonCloudFormation])
   val req                   = new ListStacksRequest().withStackStatusFilters(actors.workflow.tasks.StackList.stackStatusFilters: _*)
   val successStackSummaries = Seq(new StackSummary().withStackName("some-stack-id-1"), new StackSummary().withStackName("some-stack-id-2"))
   val successResp           = new ListStacksResult().withStackSummaries(successStackSummaries: _*)
 
   Mockito.doThrow(new AmazonServiceException("failed")).when(failMockedClient).listStacks(req)
-  Mockito.doReturn(successResp)
+  Mockito.doReturn(successResp, Nil: _*)
   .doThrow(new AmazonClientException("connection problems"))
-  .doReturn(successResp)
+  .doReturn(successResp, Nil: _*)
   .when(mockedClient).listStacks(req)
 
   override def afterAll {

--- a/test/actors/workflow/tasks/StackLoaderSpec.scala
+++ b/test/actors/workflow/tasks/StackLoaderSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.model.{AmazonS3Exception, S3Object}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
 import org.scalatest.mock.MockitoSugar
@@ -27,25 +27,52 @@ class StackLoaderSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
   s3successObject.setKey("chadash-stacks/test-success.json")
   s3successObject.setObjectContent(new ByteArrayInputStream(Json.obj("test" -> JsString("success")).toString().getBytes("UTF-8")))
 
+  val s3successObjectWithTags = new S3Object()
+  s3successObjectWithTags.setBucketName("test-bucket-name")
+  s3successObjectWithTags.setKey("chadash-stacks/test-success-with-tags.json")
+  s3successObjectWithTags.setObjectContent(new ByteArrayInputStream(Json.obj("test" -> JsString("success")).toString().getBytes("UTF-8")))
+
+  val s3successTags = new S3Object()
+  s3successTags.setBucketName("test-bucket-name")
+  s3successTags.setKey("chadash-stacks/test-success-with-tags.tags.json")
+  s3successTags.setObjectContent(new ByteArrayInputStream(
+    Json.arr(
+      Json.obj("Key" -> JsString("Project"), "Value" -> JsString("Chadash")),
+      Json.obj("Key" -> JsString("Owner"), "Value" -> JsString("LifeWay"))
+    ).toString().getBytes("UTF-8")
+  ))
+
   val s3restartObject = new S3Object()
   s3restartObject.setBucketName("test-bucket-name")
   s3restartObject.setKey("chadash-stacks/test-aws-restart.json")
   s3restartObject.setObjectContent(new ByteArrayInputStream(Json.obj("test" -> JsString("success")).toString().getBytes("UTF-8")))
 
   Mockito.doReturn(s3successObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success.json")
+  Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success.tags.json")
+  Mockito.doReturn(s3successObjectWithTags).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.json")
+  Mockito.doReturn(s3successTags).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.tags.json")
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-down.json")
   Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(s3restartObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-restart.json")
+  Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-restart.tags.json")
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }
 
-  "A StackLoader actor" should "return a JSON value for a valid stack" in {
+  "A StackLoader actor" should "return a JSON value for a valid stack and no tags" in {
     val probe = TestProbe()
     val proxy = TaskProxyBuilder(probe, StackLoader, system, TestActorFactory)
 
     probe.send(proxy, LoadStack("test-success"))
-    probe.expectMsg(StackLoaded(Json.obj("test" -> JsString("success"))))
+    probe.expectMsg(StackLoaded(Json.obj("test" -> JsString("success")), None))
+  }
+
+  "A StackLoader actor" should "return a JSON value for a valid stack with tags when provided" in {
+    val probe = TestProbe()
+    val proxy = TaskProxyBuilder(probe, StackLoader, system, TestActorFactory)
+
+    probe.send(proxy, LoadStack("test-success-with-tags"))
+    probe.expectMsg(StackLoaded(Json.obj("test" -> JsString("success")), Some(Seq(Tag("Project", "Chadash"), Tag("Owner", "LifeWay")))))
   }
 
   it should "throw an exception if AWS is down" in {
@@ -62,7 +89,7 @@ class StackLoaderSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
     val proxy = TaskProxyBuilder(probe, StackLoader, system, TestActorFactory)
 
     probe.send(proxy, LoadStack("test-aws-restart"))
-    probe.expectMsg(StackLoaded(Json.obj("test" -> JsString("success"))))
+    probe.expectMsg(StackLoaded(Json.obj("test" -> JsString("success")), None))
   }
 
   val props = Props(new StackLoader(null, "test-bucket-name") {

--- a/test/actors/workflow/tasks/StackLoaderSpec.scala
+++ b/test/actors/workflow/tasks/StackLoaderSpec.scala
@@ -11,7 +11,6 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{AmazonS3Exception, S3Object}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import play.api.libs.json.{JsString, Json}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
@@ -19,9 +18,9 @@ import utils.{ActorFactory, PropFactory, TestConfiguration}
 import scala.concurrent.duration._
 
 class StackLoaderSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike
-                              with Matchers with MockitoSugar with BeforeAndAfterAll {
+                              with Matchers with BeforeAndAfterAll {
 
-  val mockedClient    = mock[AmazonS3]
+  val mockedClient    = Mockito.mock(classOf[AmazonS3])
   val s3successObject = new S3Object()
   s3successObject.setBucketName("test-bucket-name")
   s3successObject.setKey("chadash-stacks/test-success.json")
@@ -47,12 +46,12 @@ class StackLoaderSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.t
   s3restartObject.setKey("chadash-stacks/test-aws-restart.json")
   s3restartObject.setObjectContent(new ByteArrayInputStream(Json.obj("test" -> JsString("success")).toString().getBytes("UTF-8")))
 
-  Mockito.doReturn(s3successObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success.json")
+  Mockito.doReturn(s3successObject, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success.json")
   Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success.tags.json")
-  Mockito.doReturn(s3successObjectWithTags).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.json")
-  Mockito.doReturn(s3successTags).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.tags.json")
+  Mockito.doReturn(s3successObjectWithTags, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.json")
+  Mockito.doReturn(s3successTags, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-success-with-tags.tags.json")
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-down.json")
-  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(s3restartObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-restart.json")
+  Mockito.doThrow(new AmazonClientException("connection problems")).doReturn(s3restartObject, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-restart.json")
   Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/test-aws-restart.tags.json")
 
   override def afterAll {

--- a/test/actors/workflow/tasks/UnfreezeASGSpec.scala
+++ b/test/actors/workflow/tasks/UnfreezeASGSpec.scala
@@ -6,28 +6,27 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.ResumeProcessesRequest
+import com.amazonaws.services.autoscaling.model.{ResumeProcessesRequest, ResumeProcessesResult}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
-import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import utils.{ActorFactory, PropFactory, TestConfiguration}
 
 import scala.concurrent.duration._
 
 class UnfreezeASGSpec extends TestKit(ActorSystem("TestKit", TestConfiguration.testConfig)) with FlatSpecLike
-                              with Matchers with MockitoSugar with BeforeAndAfterAll {
+                              with Matchers with BeforeAndAfterAll {
 
-  val mockedClient       = mock[AmazonAutoScaling]
+  val mockedClient       = Mockito.mock(classOf[AmazonAutoScaling])
   val successReq         = new ResumeProcessesRequest().withAutoScalingGroupName("success-req")
   val failReq            = new ResumeProcessesRequest().withAutoScalingGroupName("fail-req")
   val clientExceptionReq = new ResumeProcessesRequest().withAutoScalingGroupName("client-exception-req")
 
   //If we don't check Mock data response, we must have throw an exception if we didn't match the request.
-  Mockito.doThrow(new IllegalArgumentException).when(mockedClient).resumeProcesses(org.mockito.Matchers.anyObject())
-  Mockito.doNothing().when(mockedClient).resumeProcesses(successReq)
+  Mockito.doThrow(new IllegalArgumentException).when(mockedClient).resumeProcesses(ArgumentMatchers.any())
+  Mockito.doReturn(new ResumeProcessesResult(), Nil: _*).when(mockedClient).resumeProcesses(successReq)
   Mockito.doThrow(new AmazonServiceException("failed")).when(mockedClient).resumeProcesses(failReq)
-  Mockito.doThrow(new AmazonClientException("client-exception-req")).doNothing().when(mockedClient).resumeProcesses(clientExceptionReq)
+  Mockito.doThrow(new AmazonClientException("client-exception-req")).doReturn(new ResumeProcessesResult(), Nil: _*).when(mockedClient).resumeProcesses(clientExceptionReq)
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/test/functional/WorkflowManagerSystemTest.scala
+++ b/test/functional/WorkflowManagerSystemTest.scala
@@ -19,7 +19,7 @@ import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, Instance, InstanceState}
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{AmazonS3Exception, S3Object}
-import org.mockito.Mockito
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import play.api.libs.json.{JsString, Json}
@@ -280,13 +280,13 @@ object WorkflowManagerSystemTest {
       existingObject.setKey("chadash-stacks/existingstack/somename.json")
       existingObject.setObjectContent(new ByteArrayInputStream(Json.obj("test" -> JsString("success")).toString().getBytes("UTF-8")))
 
-      Mockito.doReturn(s3successObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/newstack/somename.json")
+      Mockito.doReturn(s3successObject, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/newstack/somename.json")
       Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/newstack/somename.tags.json")
-      Mockito.doReturn(updateObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/somename.json")
-      Mockito.doReturn(updateObjectTags).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/somename.tags.json")
-      Mockito.doReturn(updateObject2).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/growstack.json")
+      Mockito.doReturn(updateObject, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/somename.json")
+      Mockito.doReturn(updateObjectTags, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/somename.tags.json")
+      Mockito.doReturn(updateObject2, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/growstack.json")
       Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/updatestack/growstack.tags.json")
-      Mockito.doReturn(existingObject).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/existingstack/somename.json")
+      Mockito.doReturn(existingObject, Nil: _*).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/existingstack/somename.json")
       Mockito.doThrow(new AmazonS3Exception("not found")).when(mockedClient).getObject("test-bucket-name", "chadash-stacks/existingstack/somename.tags.json")
 
       val props = Props(new StackLoader(null, "test-bucket-name") {
@@ -303,8 +303,8 @@ object WorkflowManagerSystemTest {
       val successStackSummaries = Seq(new StackSummary().withStackName("chadash-updatestack-somename-v1-0"), new StackSummary().withStackName("chadash-updatestack-growstack-v1-1"),  new StackSummary().withStackName("other-stack-name"))
       val successResp           = new ListStacksResult().withStackSummaries(successStackSummaries: _*)
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).listStacks(org.mockito.Matchers.anyObject())
-      Mockito.doReturn(successResp).when(mockedClient).listStacks(req)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).listStacks(ArgumentMatchers.any())
+      Mockito.doReturn(successResp, Nil: _*).when(mockedClient).listStacks(req)
 
       val props = Props(new StackList(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -344,10 +344,10 @@ object WorkflowManagerSystemTest {
       val growReq           = new CreateStackRequest().withTemplateBody(Json.obj("test" -> "success").toString()).withTags(growAppVersionTag).withParameters(growParams: _*).withCapabilities(Capability.CAPABILITY_IAM).withStackName("chadash-updatestack-growstack-v1-2")
 
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).createStack(org.mockito.Matchers.anyObject())
-      Mockito.doReturn(null).when(mockedClient).createStack(successReq)
-      Mockito.doReturn(null).when(mockedClient).createStack(updateReq)
-      Mockito.doReturn(null).when(mockedClient).createStack(growReq)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).createStack(ArgumentMatchers.any())
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).createStack(successReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).createStack(updateReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).createStack(growReq)
 
       val props = Props(new StackCreator(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -366,9 +366,9 @@ object WorkflowManagerSystemTest {
       val stackPendingResp        = new DescribeStacksResult().withStacks(stackPending)
       val stackCompleteResp       = new DescribeStacksResult().withStacks(stackComplete)
 
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(createCompleteReq)
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(createCompleteUpdateReq)
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(growCompleteUpdateReq)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(createCompleteReq)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(createCompleteUpdateReq)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(growCompleteUpdateReq)
 
       val props = Props(new StackCreateCompleteMonitor(null, "chadash-newstack-somename-v1-0") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -432,11 +432,11 @@ object WorkflowManagerSystemTest {
       val deleteStackIdResult = new DescribeStacksResult().withStacks(deleteStackId)
 
 
-      Mockito.doReturn(asgSuccessResult).doReturn(idSuccessResult).doReturn(growIdSuccessResult).when(mockedClient).describeStacks(successReq)
-      Mockito.doReturn(deleteStackIdResult).when(mockedClient).describeStacks(deleteReq)
-      Mockito.doReturn(asgUpdateResult).when(mockedClient).describeStacks(asgUpdateReq)
-      Mockito.doReturn(growUpdateResult).when(mockedClient).describeStacks(growUpdateReq)
-      Mockito.doReturn(growNewUpdateResult).when(mockedClient).describeStacks(growNewUpdateReq)
+      Mockito.doReturn(asgSuccessResult, Nil: _*).doReturn(idSuccessResult, Nil: _*).doReturn(growIdSuccessResult, Nil: _*).when(mockedClient).describeStacks(successReq)
+      Mockito.doReturn(deleteStackIdResult, Nil: _*).when(mockedClient).describeStacks(deleteReq)
+      Mockito.doReturn(asgUpdateResult, Nil: _*).when(mockedClient).describeStacks(asgUpdateReq)
+      Mockito.doReturn(growUpdateResult, Nil: _*).when(mockedClient).describeStacks(growUpdateReq)
+      Mockito.doReturn(growNewUpdateResult, Nil: _*).when(mockedClient).describeStacks(growNewUpdateReq)
 
 
       val props = Props(new StackInfo(null) {
@@ -454,11 +454,11 @@ object WorkflowManagerSystemTest {
       val growReq        = new SuspendProcessesRequest().withAutoScalingGroupName("chadash-updatestack-growstack-v1-1-asg07907236").withScalingProcesses(Seq("AlarmNotification", "ScheduledActions").asJava)
       val growNewASGReq  = new SuspendProcessesRequest().withAutoScalingGroupName("chadash-updatestack-growstack-v1-2-asg07907237").withScalingProcesses(Seq("AlarmNotification", "ScheduledActions").asJava)
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).suspendProcesses(org.mockito.Matchers.anyObject())
-      Mockito.doNothing().when(mockedClient).suspendProcesses(successReq)
-      Mockito.doNothing().when(mockedClient).suspendProcesses(updateSuccessReq)
-      Mockito.doNothing().when(mockedClient).suspendProcesses(growReq)
-      Mockito.doNothing().when(mockedClient).suspendProcesses(growNewASGReq)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).suspendProcesses(ArgumentMatchers.any())
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).suspendProcesses(successReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).suspendProcesses(updateSuccessReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).suspendProcesses(growReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).suspendProcesses(growNewASGReq)
 
       val props = Props(new FreezeASG(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -486,13 +486,13 @@ object WorkflowManagerSystemTest {
       val growDesiredCapSetRequest     = new SetDesiredCapacityRequest().withAutoScalingGroupName("chadash-updatestack-growstack-v1-2-asg07907237").withDesiredCapacity(4)
 
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).setDesiredCapacity(org.mockito.Matchers.anyObject())
-      Mockito.doReturn(describeASGResult).when(mockedClient).describeAutoScalingGroups(describeASGReq)
-      Mockito.doReturn(describeNewASGResult).when(mockedClient).describeAutoScalingGroups(describeNewASGReq)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).setDesiredCapacity(ArgumentMatchers.any())
+      Mockito.doReturn(describeASGResult, Nil: _*).when(mockedClient).describeAutoScalingGroups(describeASGReq)
+      Mockito.doReturn(describeNewASGResult, Nil: _*).when(mockedClient).describeAutoScalingGroups(describeNewASGReq)
 
-      Mockito.doReturn(growDescribeASGResult).when(mockedClient).describeAutoScalingGroups(growASGReq)
-      Mockito.doReturn(growDescribeNewASGResult).when(mockedClient).describeAutoScalingGroups(growDescribeNewASGReq)
-      Mockito.doNothing().when(mockedClient).setDesiredCapacity(growDesiredCapSetRequest)
+      Mockito.doReturn(growDescribeASGResult, Nil: _*).when(mockedClient).describeAutoScalingGroups(growASGReq)
+      Mockito.doReturn(growDescribeNewASGResult, Nil: _*).when(mockedClient).describeAutoScalingGroups(growDescribeNewASGReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).setDesiredCapacity(growDesiredCapSetRequest)
 
       val props = Props(new ASGSize(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -569,9 +569,9 @@ object WorkflowManagerSystemTest {
       val stackPendingResp   = new DescribeStacksResult().withStacks(stackPending)
       val stackCompleteResp  = new DescribeStacksResult().withStacks(stackComplete)
 
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(deleteCompleteReq)
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(growDeleteComplete)
-      Mockito.doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackPendingResp).doReturn(stackCompleteResp).when(mockedClient).describeStacks(deleteCompleteReq2)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(deleteCompleteReq)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(growDeleteComplete)
+      Mockito.doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackPendingResp, Nil: _*).doReturn(stackCompleteResp, Nil: _*).when(mockedClient).describeStacks(deleteCompleteReq2)
 
       val props = Props(new StackDeleteCompleteMonitor(null, "some-stack-id", "chadash-newstack-somename-v1-0") {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -603,9 +603,9 @@ object WorkflowManagerSystemTest {
       val successReq   = new ResumeProcessesRequest().withAutoScalingGroupName("chadash-updatestack-somename-sv20-av1-1-asg07907234")
       val growReq      = new ResumeProcessesRequest().withAutoScalingGroupName("chadash-updatestack-growstack-v1-2-asg07907237")
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).resumeProcesses(org.mockito.Matchers.anyObject())
-      Mockito.doNothing().when(mockedClient).resumeProcesses(successReq)
-      Mockito.doNothing().when(mockedClient).resumeProcesses(growReq)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).resumeProcesses(ArgumentMatchers.any())
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).resumeProcesses(successReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).resumeProcesses(growReq)
 
       val props = Props(new UnfreezeASG(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -620,10 +620,10 @@ object WorkflowManagerSystemTest {
       val growReq        = new DeleteStackRequest().withStackName("chadash-updatestack-growstack-v1-1")
       val deleteStackReq = new DeleteStackRequest().withStackName("chadash-updatestack-somename-v1-2")
 
-      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).deleteStack(org.mockito.Matchers.anyObject())
-      Mockito.doNothing().when(mockedClient).deleteStack(successReq)
-      Mockito.doNothing().when(mockedClient).deleteStack(growReq)
-      Mockito.doNothing().when(mockedClient).deleteStack(deleteStackReq)
+      Mockito.doThrow(new IllegalArgumentException).when(mockedClient).deleteStack(ArgumentMatchers.any())
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).deleteStack(successReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).deleteStack(growReq)
+      Mockito.doReturn(null, Nil: _*).when(mockedClient).deleteStack(deleteStackReq)
 
       val props = Props(new DeleteStack(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds
@@ -638,7 +638,7 @@ object WorkflowManagerSystemTest {
       val stackSummaries = new StackSummary().withStackName("chadash-existingstack-somename-v1-0")
       val response = new ListStacksResult().withStackSummaries(stackSummaries)
 
-      Mockito.doReturn(response).when(mockedClient).listStacks(existingReq)
+      Mockito.doReturn(response, Nil: _*).when(mockedClient).listStacks(existingReq)
 
       val props = Props(new actors.workflow.tasks.StackList(null) {
         override def pauseTime(): FiniteDuration = 5.milliseconds


### PR DESCRIPTION
LifeWay is no longer actively maintaining Chadash. However, as we still have some projects using it we needed to improve the process by which stack resources are tagged.

CloudFormation supports adding tags to the stack as a unit, and then every single resource within that stack will get those tags applied to it if that resource supports tagging. The resource within the stack will override the value of a tag if the stack resource specifies the same tag with a different value than that of the entire stack.

To use this feature, along side the same stack json file in your s3 bucket, optionally add a second file by the same file name with the following extension: ".tags.json" For example, if I had a stack in my s3 bucket: `/chadash-stacks/xyzproject/mything.json` then the optional tags file would be here : `/chadash-stacks/xyzproject/mything.tags.json`

The contents of the Tags file follows the same syntax as CloudFormation Tags and is a JS array. For instance, the following would be a valid tags file:
```json
[
  {
    "Key" : "Project",
    "Value" : "Chadash"
  },
  {
    "Key" : "Application",
    "Value" : "ChadashServer"
  }
]
```